### PR TITLE
Optimize code generation for native platform

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 ## [0.8.1] - Unreleased
 ### Improvements
 - Reduced stats tracking overhead when using Cython
+- Optimize code generation for the native platform by default
 
 ## [0.8.0] - 2020-11-19
 ### Changes


### PR DESCRIPTION
Unless we build a wheel, in which case we can override with environment
variables, the platform building will be the platform running as
pip will install from source.

In that case, passing `-mtune=native` to GCC can speed up code, and it's
a very lightweight change so it's more than worth the trouble.