### PR TITLE
Benchmark suite and threadpool benchmarks

### DIFF
--- a/bench/benchmarks/__init__.py
+++ b/bench/benchmarks/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from . import threadpool
+
+BENCHMARKS = (
+    threadpool.BENCHMARKS
+)
+
+__all__ = ['BENCHMARKS']

--- a/bench/benchmarks/base.py
+++ b/bench/benchmarks/base.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function
+from future.builtins import range
+
+import time
+import timeit
+import functools
+import math
+
+from .utils import prettytime
+
+class Benchmark(object):
+    initial = 1000
+    calibration_runs = 1000000
+    maxloops = 10
+    maxruns = 1000000
+    bench_prefix = ''
+
+    def __init__(self, description, **kw):
+        self.description = description
+        # Not calling super, because super is object and doesn't take kwargs
+        # Thus, for multiple inheritance to work, make sure to always inherit
+        # from Benchmark LAST
+
+    def run(self, series = 10, runtime = 5.0, warmup = 1, timer = time.time, verbose = False, **kw):
+        print("---", self.bench_prefix, '-', self.description, "---")
+
+        initial = self.initial
+        calibration_runs = self.calibration_runs
+        maxloops = self.maxloops
+        maxruns = self.maxruns
+        max_test_overhead = runtime * 10
+
+        percall_series = []
+        for s in range(series + warmup):
+            state = self.setup()
+
+            calibration_time = timeit.timeit(
+                functools.partial(self.calibration, **state),
+                number=calibration_runs) / float(calibration_runs)
+            if verbose and not s:
+                print("    ", prettytime(calibration_time), "per run overhead")
+
+            times = []
+            runs = []
+            current_runs = initial
+            start_time = time.time()
+            for r in range(maxloops):
+                times.append(
+                    max(0,
+                        timeit.timeit(functools.partial(self.func, **state), number=current_runs)
+                        - calibration_time * current_runs
+                    )
+                )
+                runs.append(current_runs)
+                total_runtime = sum(times)
+                if total_runtime >= runtime or (time.time() - start_time) > max_test_overhead:
+                    break
+
+                total_runs = sum(runs)
+                if total_runtime <= 0:
+                    # Probably some snafu with calibration
+                    current_runs *= 2
+                else:
+                    current_runs = int(max(initial, (runtime - total_runtime) / (total_runtime / total_runs)))
+                current_runs = max(initial, min(current_runs, maxruns))
+            self.cleanup(**state)
+
+            if s >= warmup:
+                percall_series.extend([ t/r for t,r in zip(times, runs) ])
+
+            if verbose:
+                print(
+                    "    ", sum(runs), "runs in", prettytime(sum(times)),
+                    " (", prettytime(sum(times)/sum(runs)), " per call)",
+                    end='')
+                if s >= warmup:
+                    print()
+                else:
+                    print(" - warmup run")
+
+        avg = sum(percall_series) / len(percall_series)
+        print("  avg:", prettytime(avg))
+        print("  max:", prettytime(max(percall_series)))
+        print("  min:", prettytime(min(percall_series)))
+        print("  std:", prettytime(math.sqrt(sum([ (pc-avg)*(pc-avg) for pc in percall_series ]) / len(percall_series))))
+
+    def setup(self):
+        return {}
+
+    def calibration(self):
+        pass
+
+    def cleanup(self):
+        pass

--- a/bench/benchmarks/threadpool.py
+++ b/bench/benchmarks/threadpool.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import threading
+from past.builtins import xrange as range
+
+from .base import Benchmark
+from chorde.threadpool import ThreadPool
+
+
+class BenchThreadpoolBase(Benchmark):
+
+    def __init__(self, prefix=[], nthreads=1, **kw):
+        self.bench_prefix = '.'.join(['threadpool'] + prefix + ['%dt' % nthreads])
+        self.nthreads = nthreads
+        super(BenchThreadpoolBase, self).__init__(
+            description = self.bench_prefix,
+            **kw)
+
+    def setup(self):
+        return dict(
+            threadpool=ThreadPool(self.nthreads)
+        )
+
+class BenchThreadpoolLatency(BenchThreadpoolBase):
+
+    def __init__(self, **kw):
+        super(BenchThreadpoolLatency, self).__init__(prefix=['latench'], **kw)
+
+    def calibration(self, threadpool):
+        lambda:None
+        threadpool.apply
+
+    def func(self, threadpool):
+        threadpool.apply(lambda:None, timeout=1)
+
+    def cleanup(self, threadpool):
+        threadpool.join(4)
+        threadpool.terminate()
+
+class BenchThreadpoolThoughput(BenchThreadpoolBase):
+
+    calibration_runs = 100000
+
+    def __init__(self, batchsize=100, nqueues=1, **kw):
+        self.batchsize = batchsize
+        self.nqueues = nqueues
+        super(BenchThreadpoolThoughput, self).__init__(
+            prefix=['thoughput', 'batch%d' % batchsize, 'q%d' % nqueues], **kw)
+
+    def calibration(self, threadpool):
+        t = lambda:None
+        nq = self.nqueues
+        for i in range(self.batchsize * nq):
+            i % nq
+            threadpool.apply_async
+        evs = []
+        for q in range(nq):
+            evs.append(threading.Event())
+            threadpool.apply_async
+        for ev in evs:
+            ev.isSet
+            ev.wait
+
+    def func(self, threadpool):
+        t = lambda:None
+        nq = self.nqueues
+        for i in range(self.batchsize * nq):
+            threadpool.apply_async(t, queue=i % nq)
+        evs = []
+        for q in range(nq):
+            ev = threading.Event()
+            evs.append(ev)
+            threadpool.apply_async(ev.set, queue=q)
+        for ev in evs:
+            if not ev.isSet():
+                ev.wait(1)
+
+    def cleanup(self, threadpool):
+        threadpool.join(4)
+        threadpool.terminate()
+
+BENCHMARKS = [
+    bench_class(nthreads=nthreads)
+    for nthreads in [1,4]
+    for bench_class in [
+        BenchThreadpoolLatency,
+    ]
+] + [
+    bench_class(nthreads=nthreads, nqueues=nqueues, batchsize=batchsize)
+    for nthreads in [1,4]
+    for nqueues in [1,4]
+    for batchsize in [10, 100]
+    for bench_class in [
+        BenchThreadpoolThoughput,
+    ]
+]

--- a/bench/benchmarks/threadpool.py
+++ b/bench/benchmarks/threadpool.py
@@ -25,7 +25,7 @@ class BenchThreadpoolBase(Benchmark):
 class BenchThreadpoolLatency(BenchThreadpoolBase):
 
     def __init__(self, **kw):
-        super(BenchThreadpoolLatency, self).__init__(prefix=['latench'], **kw)
+        super(BenchThreadpoolLatency, self).__init__(prefix=['latency'], **kw)
 
     def calibration(self, threadpool):
         lambda:None

--- a/bench/benchmarks/utils.py
+++ b/bench/benchmarks/utils.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+times = [
+    (1, 's', '%.3f'),
+    (0.001, 'ms', '%.3f'),
+    (0.000001, 'us', '%.3f'),
+    (0.000000001, 'ns', '%.3f'),
+]
+
+def prettygen(size, separator, scales, margin):
+    for scale, unit, fmt in scales:
+        if size > (margin * scale):
+            break
+    return separator.join([fmt % (float(size) / (scale if scale > 0 else 1)), unit])
+
+def prettytime(size, separator = ' '):
+    return prettygen(size, separator, times, 2)

--- a/bench/run_benchmarks.py
+++ b/bench/run_benchmarks.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+import time
+import argparse
+import sys
+import os.path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
+
+def sfilter(suite, key):
+    return suite is None or key.startswith(suite)
+
+def bench_all(suite, just_list, **kw):
+    for bench in benchmarks.BENCHMARKS:
+        if sfilter(suite, bench.bench_prefix):
+            if just_list:
+                print(bench.bench_prefix, "-", bench.description)
+            else:
+                bench.run(**kw)
+
+def bench(args):
+    if args.cputime:
+        clock = time.clock
+    else:
+        clock = time.time
+    bench_all(
+        timer=clock, verbose=args.verbose, series=args.series, runtime=args.runtime,
+        suite=args.bench_suite, just_list=args.list)
+
+if __name__ == '__main__':
+    args_parser = argparse.ArgumentParser()
+    args_parser.add_argument('--cpu-time', dest="cputime", action="store_true", default=False,
+        help = "Use CPU time as clock, rather than real-time")
+    args_parser.add_argument('-v', '--verbose', action="store_true", default=False,
+        help = "Show verbose progress messages")
+    args_parser.add_argument('-l', '--list', action="store_true",
+        help = "List all available menchmark suites")
+    args_parser.add_argument('-S', '--series', type=int, default=10,
+        help = "Specify how many series of runs to execute to get runtime statistics")
+    args_parser.add_argument('-T', '--runtime', type=float, default=5.0,
+        help =
+            "Target runtime of each series of runs. The benchmark will loop until it "
+            "accumulates about this much calibrated runtime")
+    args_parser.add_argument('-s', '--bench-suite', dest='bench_suite',
+        help =
+            "Pick a specific benchmark suite by its id prefix. A partial prefix can "
+            "be supplied that may match multiple benchmarks")
+
+    args = args_parser.parse_args()
+
+    import benchmarks
+
+    bench(args)
+

--- a/bench/run_benchmarks.py
+++ b/bench/run_benchmarks.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     args_parser.add_argument('-v', '--verbose', action="store_true", default=False,
         help = "Show verbose progress messages")
     args_parser.add_argument('-l', '--list', action="store_true",
-        help = "List all available menchmark suites")
+        help = "List all available benchmark suites")
     args_parser.add_argument('-S', '--series', type=int, default=10,
         help = "Specify how many series of runs to execute to get runtime statistics")
     args_parser.add_argument('-T', '--runtime', type=float, default=5.0,


### PR DESCRIPTION
Create the skeleton for the benchmark suite, and add the first
benchmark, threadpool benchmarks.

Benchmark results:

```
--- threadpool.latench.1t - threadpool.latench.1t ---
  avg (arm): 1078.061 us
  avg (x86): 992.543 us
--- threadpool.latench.4t - threadpool.latench.4t ---
  avg (arm): 736.077 us
  avg (x86): 922.408 us
--- threadpool.thoughput.batch10.q1.1t - threadpool.thoughput.batch10.q1.1t ---
  avg (arm): 1086.941 us
  avg (x86): 1230.972 us
--- threadpool.thoughput.batch100.q1.1t - threadpool.thoughput.batch100.q1.1t ---
  avg (arm): 1227.826 us
  avg (x86): 1908.554 us
--- threadpool.thoughput.batch10.q4.1t - threadpool.thoughput.batch10.q4.1t ---
  avg (arm): 1141.176 us
  avg (x86): 1487.390 us
--- threadpool.thoughput.batch100.q4.1t - threadpool.thoughput.batch100.q4.1t ---
  avg (arm): 3.764 ms
  avg (x86): 3.962 ms
--- threadpool.thoughput.batch10.q1.4t - threadpool.thoughput.batch10.q1.4t ---
  avg (arm): 1184.873 us
  avg (x86): 1268.988 us
--- threadpool.thoughput.batch100.q1.4t - threadpool.thoughput.batch100.q1.4t ---
  avg (arm): 1945.014 us
  avg (x86): 1941.382 us
--- threadpool.thoughput.batch10.q4.4t - threadpool.thoughput.batch10.q4.4t ---
  avg (arm): 1553.996 us
  avg (x86): 1545.813 us
--- threadpool.thoughput.batch100.q4.4t - threadpool.thoughput.batch100.q4.4t ---
  avg (arm): 4.636 ms
  avg (x86): 5.009 ms
```
