### PR TITLE
Threadpool benching py3

### DIFF
--- a/lib/chorde/threadpool.py
+++ b/lib/chorde/threadpool.py
@@ -247,7 +247,7 @@ class ThreadPool:
             self.__dequeue = iter(iqueue).__next__
             if itotal:
                 ftotal = float(itotal)
-                self.__busyfactors = dict([(qname, quant/ftotal) for qname,quant in iquantities.items()])
+                self.__busyfactors = {qname: quant/ftotal for qname,quant in iquantities.items()}
             else:
                 self.__busyfactors = {}
         elif self.__dequeue is not self.__exhausted:

--- a/lib/chorde/threadpool.py
+++ b/lib/chorde/threadpool.py
@@ -486,17 +486,17 @@ class ThreadPool:
         self._enqueue(queue, task)
 
     def apply(self, task, args = (), kwargs = {}, queue = None, timeout = None):
-        rv = []
+        rv = None
         ev = threading.Event()
         def stask():
+            nonlocal rv
             try:
-                rv.append(task(*args, **kwargs))
+                rv = task(*args, **kwargs)
             except:
-                rv.append(ExceptionWrapper(sys.exc_info()))
+                rv = ExceptionWrapper(sys.exc_info())
             ev.set()
         self._enqueue(queue, stask)
         if ev.wait(timeout):
-            rv = rv[0]
             if isinstance(rv, ExceptionWrapper):
                 rv.reraise()
             else:


### PR DESCRIPTION
Py3 fixes and perf tweaks based on threadpool benching.

Also merges the threadpool_benching branch and some changes from master.

Benchmark results:

```
--- threadpool.latench.1t - threadpool.latench.1t ---
  2.7: avg (arm): 1078.061 us
  3.7: avg (arm): 56.893 us
  2.7: avg (x86): 992.543 us
  3.7: avg (x86): 78.267 us
--- threadpool.latench.4t - threadpool.latench.4t ---
  2.7: avg (arm): 736.077 us
  3.7: avg (arm): 83.801 us
  2.7: avg (x86): 922.408 us
  3.7: avg (x86): 155.584 us
--- threadpool.thoughput.batch10.q1.1t - threadpool.thoughput.batch10.q1.1t ---
  2.7: avg (arm): 1086.941 us
  3.7: avg (arm): 96.602 us
  2.7: avg (x86): 1230.972 us
  3.7: avg (x86): 112.578 us
--- threadpool.thoughput.batch100.q1.1t - threadpool.thoughput.batch100.q1.1t ---
  2.7: avg (arm): 1227.826 us
  3.7: avg (arm): 463.889 us
  2.7: avg (x86): 1908.554 us
  3.7: avg (x86): 399.105 us
--- threadpool.thoughput.batch10.q4.1t - threadpool.thoughput.batch10.q4.1t ---
  2.7: avg (arm): 1141.176 us
  3.7: avg (arm): 254.000 us
  2.7: avg (x86): 1487.390 us
  3.7: avg (x86): 235.650 us
--- threadpool.thoughput.batch100.q4.1t - threadpool.thoughput.batch100.q4.1t ---
  2.7: avg (arm): 3.764 ms
  3.7: avg (arm): 1721.725 us
  2.7: avg (x86): 3.962 ms
  3.7: avg (x86): 1378.640 us
--- threadpool.thoughput.batch10.q1.4t - threadpool.thoughput.batch10.q1.4t ---
  2.7: avg (arm): 1184.873 us
  3.7: avg (arm): 149.491 us
  2.7: avg (x86): 1268.988 us
  3.7: avg (x86): 192.231 us
--- threadpool.thoughput.batch100.q1.4t - threadpool.thoughput.batch100.q1.4t ---
  2.7: avg (arm): 1945.014 us
  3.7: avg (arm): 518.377 us
  2.7: avg (x86): 1941.382 us
  3.7: avg (x86): 478.975 us
--- threadpool.thoughput.batch10.q4.4t - threadpool.thoughput.batch10.q4.4t ---
  2.7: avg (arm): 1553.996 us
  3.7: avg (arm): 310.911 us
  2.7: avg (x86): 1545.813 us
  3.7: avg (x86): 318.030 us
--- threadpool.thoughput.batch100.q4.4t - threadpool.thoughput.batch100.q4.4t ---
  2.7: avg (arm): 4.636 ms
  3.7: avg (arm): 1784.926 us
  2.7: avg (x86): 5.009 ms
  3.7: avg (x86): 1466.505 us
```

**Summary**

There's some extreme multiple orders-of-magnitude speedups to be had in the latency benchmarks, and significant 2-fold and up speedups in throughput benchmarks.

Thoughput benchmarks are quite sensitive to the exact workload being benchmarked, so they may not always translate to application speedups, but at least the benchmarks themselves don't show regressions. On the contrary, they show speedups.

This is probably related to the GIL and thread locking improvements done on the 3.x branches. Quite cool.
