### PR TITLE
Add inproc cache benchmarks

### DIFF
--- a/bench/benchmarks/__init__.py
+++ b/bench/benchmarks/__init__.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import threadpool
+from . import threadpool, inproc
 
 BENCHMARKS = (
     threadpool.BENCHMARKS
+    + inproc.BENCHMARKS
 )
 
 __all__ = ['BENCHMARKS']

--- a/bench/benchmarks/inproc.py
+++ b/bench/benchmarks/inproc.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import threading
+from random import random, choice
+from past.builtins import xrange as range
+
+from .base import Benchmark
+from chorde.clients.inproc import InprocCacheClient, CuckooCache
+
+
+class BenchInprocBase(Benchmark):
+
+    ClientClass = InprocCacheClient
+    ClientName = 'lru'
+    MethodName = 'base'
+
+    def __init__(self, prefix=[], size=100, **kw):
+        self.bench_prefix = '.'.join(["inproc", self.MethodName, self.ClientName] + prefix + ['sz%d' % size])
+        self.size = size
+        super(BenchInprocBase, self).__init__(
+            description = self.bench_prefix,
+            **kw)
+
+    def setup(self):
+        return dict(
+            c=self.ClientClass(self.size)
+        )
+
+class BenchInprocPut(BenchInprocBase):
+
+    MethodName = 'put'
+
+    def calibration(self, c):
+        random()
+        c.put
+
+    def func(self, c):
+        c.put(random(), 5, 60)
+
+    def cleanup(self, c):
+        c.clear()
+
+
+class BenchInprocGet(BenchInprocBase):
+
+    MethodName = 'get'
+
+    def setup(self):
+        c = self.ClientClass(self.size)
+        k = set()
+        for i in range(self.size):
+            k.add(i)
+            c.put(i, i, 86400)
+        return dict(c=c, keys=list(k))
+
+    def calibration(self, c, keys):
+        choice(keys)
+        c.get
+
+    def func(self, c, keys):
+        c.get(choice(keys), None)
+
+    def cleanup(self, c, keys):
+        c.clear()
+        del keys[:]
+
+
+class BenchInprocContains(BenchInprocBase):
+
+    MethodName = 'contains'
+
+    def setup(self):
+        c = self.ClientClass(self.size)
+        k = set()
+        for i in range(self.size * 2):
+            k.add(i)
+            if i % 2:
+                c.put(i, i, 86400)
+        return dict(c=c, keys=list(k))
+
+    def calibration(self, c, keys):
+        choice(keys)
+        c.contains
+
+    def func(self, c, keys):
+        c.contains(choice(keys), None)
+
+    def cleanup(self, c, keys):
+        c.clear()
+        del keys[:]
+
+
+class BenchInprocCuckooMixIn:
+
+    ClientName = 'cuckoo'
+
+    @staticmethod
+    def ClientClass(*p, **kw):
+        return InprocCacheClient(*p, store_class=CuckooCache, **kw)
+
+
+class BenchInprocPutCuckoo(BenchInprocCuckooMixIn, BenchInprocPut):
+    pass
+
+
+class BenchInprocGetCuckoo(BenchInprocCuckooMixIn, BenchInprocGet):
+    pass
+
+
+class BenchInprocContainsCuckoo(BenchInprocCuckooMixIn, BenchInprocContains):
+    pass
+
+
+BENCHMARKS = [
+    bench_class(size=size)
+    for size in [100,10000]
+    for bench_class in [
+        BenchInprocPut,
+        BenchInprocPutCuckoo,
+        BenchInprocGet,
+        BenchInprocGetCuckoo,
+        BenchInprocContains,
+        BenchInprocContainsCuckoo,
+    ]
+]

--- a/bench/run_benchmarks.py
+++ b/bench/run_benchmarks.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+
 import time
 import argparse
 import sys


### PR DESCRIPTION
Benchmark results:

```
--- inproc.put.lru.sz100 - inproc.put.lru.sz100 ---
  avg (arm): 499.032 ns
  avg (x86): 343.127 ns
--- inproc.put.cuckoo.sz100 - inproc.put.cuckoo.sz100 ---
  avg (arm): 367.133 ns
  avg (x86): 211.099 ns
--- inproc.get.lru.sz100 - inproc.get.lru.sz100 ---
  avg (arm): 643.504 ns
  avg (x86): 431.284 ns
--- inproc.get.cuckoo.sz100 - inproc.get.cuckoo.sz100 ---
  avg (arm): 633.002 ns
  avg (x86): 377.529 ns
--- inproc.contains.lru.sz100 - inproc.contains.lru.sz100 ---
  avg (arm): 315.200 ns
  avg (x86): 219.688 ns
--- inproc.contains.cuckoo.sz100 - inproc.contains.cuckoo.sz100 ---
  avg (arm): 293.750 ns
  avg (x86): 190.246 ns
--- inproc.put.lru.sz10000 - inproc.put.lru.sz10000 ---
  avg (arm): 787.642 ns
  avg (x86): 474.562 ns
--- inproc.put.cuckoo.sz10000 - inproc.put.cuckoo.sz10000 ---
  avg (arm): 441.580 ns
  avg (x86): 262.902 ns
--- inproc.get.lru.sz10000 - inproc.get.lru.sz10000 ---
  avg (arm): 943.189 ns
  avg (x86): 552.246 ns
--- inproc.get.cuckoo.sz10000 - inproc.get.cuckoo.sz10000 ---
  avg (arm): 784.890 ns
  avg (x86): 442.928 ns
--- inproc.contains.lru.sz10000 - inproc.contains.lru.sz10000 ---
  avg (arm): 554.663 ns
  avg (x86): 315.045 ns
--- inproc.contains.cuckoo.sz10000 - inproc.contains.cuckoo.sz10000 ---
  avg (arm): 397.809 ns
  avg (x86): 232.532 ns
```
