### PR TITLE
Py3 fixes for inproc

### DIFF
--- a/lib/chorde/clients/inproc.py
+++ b/lib/chorde/clients/inproc.py
@@ -242,16 +242,12 @@ class InprocCacheClient(base.BaseCacheClient):
         return retentions
 
     def contains(self, key, ttl = None, baseNONE = base.NONE, time = time.time):
-        if key in self.store:
+        rv = self.store.get(key, baseNONE)
+        if rv is not baseNONE:
             if ttl is None:
                 ttl = 0
-
-            rv = self.store.get(key, baseNONE)
-            if rv is not baseNONE:
-                store_ttl = rv[1] - time()
-                return store_ttl > ttl
-            else:
-                return False
+            store_ttl = rv[1] - time()
+            return store_ttl > ttl
         else:
             return False
 


### PR DESCRIPTION
This is a transitional PR, no changes yet, but other PRs will be merged onto this one.

Benchmark results:

```
--- inproc.put.lru.sz100 - inproc.put.lru.sz100 ---
  2.7: avg (arm): 499.032 ns
  3.7: avg (arm): 594.103 ns
  2.7: avg (x86): 343.127 ns
  3.7: avg (x86): 438.778 ns
--- inproc.put.cuckoo.sz100 - inproc.put.cuckoo.sz100 ---
  2.7: avg (arm): 367.133 ns
  3.7: avg (arm): 420.714 ns
  2.7: avg (x86): 211.099 ns
  3.7: avg (x86): 296.748 ns
--- inproc.get.lru.sz100 - inproc.get.lru.sz100 ---
  2.7: avg (arm): 643.504 ns
  3.7: avg (arm): 803.053 ns
  2.7: avg (x86): 431.284 ns
  3.7: avg (x86): 621.519 ns
--- inproc.get.cuckoo.sz100 - inproc.get.cuckoo.sz100 ---
  2.7: avg (arm): 633.002 ns
  3.7: avg (arm): 825.904 ns
  2.7: avg (x86): 377.529 ns
  3.7: avg (x86): 610.856 ns
--- inproc.contains.lru.sz100 - inproc.contains.lru.sz100 ---
  2.7: avg (arm): 315.200 ns
  3.7: avg (arm): 449.535 ns
  2.7: avg (x86): 219.688 ns
  3.7: avg (x86): 346.009 ns
--- inproc.contains.cuckoo.sz100 - inproc.contains.cuckoo.sz100 ---
  2.7: avg (arm): 293.750 ns
  3.7: avg (arm): 402.053 ns
  2.7: avg (x86): 190.246 ns
  3.7: avg (x86): 323.732 ns
--- inproc.put.lru.sz10000 - inproc.put.lru.sz10000 ---
  2.7: avg (arm): 787.642 ns
  3.7: avg (arm): 787.305 ns
  2.7: avg (x86): 474.562 ns
  3.7: avg (x86): 518.720 ns
--- inproc.put.cuckoo.sz10000 - inproc.put.cuckoo.sz10000 ---
  2.7: avg (arm): 441.580 ns
  3.7: avg (arm): 439.671 ns
  2.7: avg (x86): 262.902 ns
  3.7: avg (x86): 318.042 ns
--- inproc.get.lru.sz10000 - inproc.get.lru.sz10000 ---
  2.7: avg (arm): 943.189 ns
  3.7: avg (arm): 1164.870 ns
  2.7: avg (x86): 552.246 ns
  3.7: avg (x86): 795.462 ns
--- inproc.get.cuckoo.sz10000 - inproc.get.cuckoo.sz10000 ---
  2.7: avg (arm): 784.890 ns
  3.7: avg (arm): 1021.718 ns
  2.7: avg (x86): 442.928 ns
  3.7: avg (x86): 717.050 ns
--- inproc.contains.lru.sz10000 - inproc.contains.lru.sz10000 ---
  2.7: avg (arm): 554.663 ns
  3.7: avg (arm): 684.754 ns
  2.7: avg (x86): 315.045 ns
  3.7: avg (x86): 466.122 ns
--- inproc.contains.cuckoo.sz10000 - inproc.contains.cuckoo.sz10000 ---
  2.7: avg (arm): 397.809 ns
  3.7: avg (arm): 508.422 ns
  2.7: avg (x86): 232.532 ns
  3.7: avg (x86): 383.460 ns
```

There's a consistent performance regression here, so it may need some extra work.