### PR TITLE
Decorator benchmarks and fix async latency issue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@ All notable changes to this project will be documented here.
 - Lock pools and deadlock detection from chorde.serialize have
   been removed (no longer used)
 
+### Bugfixes
+- Fixed high latench (50ms) of missing `async()()` calls
+
 ## [0.8.4] - 2021-09-29
 ### Bugfixes
 - Apply TTL namespace variation on all code paths.

--- a/bench/benchmarks/__init__.py
+++ b/bench/benchmarks/__init__.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import threadpool, inproc, spickle
+from . import threadpool, inproc, spickle, decorators
 
 BENCHMARKS = (
     threadpool.BENCHMARKS
     + inproc.BENCHMARKS
     + spickle.BENCHMARKS
+    + decorators.BENCHMARKS
 )
 
 __all__ = ['BENCHMARKS']

--- a/bench/benchmarks/decorators.py
+++ b/bench/benchmarks/decorators.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from random import random, choice
+
+from .base import Benchmark
+from chorde import decorators
+from chorde.clients import inproc
+
+
+class BenchSimpleDecorator(Benchmark):
+
+    key = b"blarg"
+    bench_prefix = 'decorators.simple'
+    ttl = 3600
+    initial = 200
+
+    def __init__(self, size, rndspace):
+        self.rndspace = rndspace
+        self.size = size
+        self.bench_prefix = self.bench_prefix + '.sz%d_rnd%d' % (size, rndspace)
+        super(BenchSimpleDecorator, self).__init__(
+            description='Simple decorator, lru size %d, argument space %d' % (size, rndspace))
+
+    @staticmethod
+    def callmode(func):
+        return func
+
+    def setup(self):
+        @decorators.cached(inproc.InprocCacheClient(self.size), ttl=self.ttl)
+        def func(x):
+            return x
+        
+        return dict(
+            f=self.callmode(func)
+        )
+
+    def calibration(self, f):
+        int(random() * self.rndspace)
+
+    def func(self, f):
+        f(int(random() * self.rndspace))
+
+
+class BenchBgDecorator(BenchSimpleDecorator):
+
+    bench_prefix = 'decorators.bg.sync'
+
+    @staticmethod
+    def callmode(func):
+        return func.async()
+
+
+class BenchBgLazyDecorator(BenchSimpleDecorator):
+
+    bench_prefix = 'decorators.bg.lazy'
+
+    @staticmethod
+    def callmode(func):
+        func = func.async()
+        def fcall(*p, **kw):
+            try:
+                return func(*p, **kw)
+            except Exception:
+                pass
+        return fcall
+
+
+class BenchFutureDecorator(BenchSimpleDecorator):
+
+    bench_prefix = 'decorators.future'
+
+    @staticmethod
+    def callmode(func):
+        func = func.future()
+        def fcall(*p, **kw):
+            return func(*p, **kw).result()
+        return fcall
+
+
+BENCHMARKS = [
+    cls(100, spc)
+    for cls in (BenchSimpleDecorator, BenchBgDecorator, BenchBgLazyDecorator, BenchFutureDecorator)
+    for spc in (100, 1000)
+]

--- a/bench/benchmarks/decorators.py
+++ b/bench/benchmarks/decorators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from random import random, choice
+from random import random
 
 from .base import Benchmark
 from chorde import decorators

--- a/lib/chorde/clients/async.py
+++ b/lib/chorde/clients/async.py
@@ -477,8 +477,9 @@ class AsyncCacheWriterPool:
                     else:
                         busyloop += 1
                         if busyloop > 5:
-                            if ev is done_event and busyloop > 20 and ev.isSet():
-                                ev.clear()
+                            if ev is done_event:
+                                if busyloop > 20 and ev.isSet():
+                                    ev.clear()
                             else:
                                 sleep(0.05)
                 else:
@@ -500,8 +501,9 @@ class AsyncCacheWriterPool:
                     else:
                         busyloop += 1
                         if busyloop > 5:
-                            if ev is done_event and busyloop > 20 and ev.isSet():
-                                ev.clear()
+                            if ev is done_event:
+                                if busyloop > 20 and ev.isSet():
+                                    ev.clear()
                             else:
                                 sleep(0.05)
                 else:


### PR DESCRIPTION
- Add decorators benchmark
- Fix async()() call excessive latency issue uncovered by benchmarks

Benchmarks (py2):

```
--- decorators.simple.sz100_rnd100 - Simple decorator, lru size 100, argument space 100 ---
  avg (arm): 2.350 us
  avg (x86): 1506.241 ns
--- decorators.simple.sz100_rnd1000 - Simple decorator, lru size 100, argument space 1000 ---
  avg (arm): 5.414 us
  avg (x86): 3.196 us
--- decorators.bg.sync.sz100_rnd100 - Simple decorator, lru size 100, argument space 100 ---
  avg (arm): 63.141 us
  avg (x86): 24.494 us
--- decorators.bg.sync.sz100_rnd1000 - Simple decorator, lru size 100, argument space 1000 ---
  avg (arm): 1018.611 us
  avg (x86): 358.925 us
--- decorators.bg.lazy.sz100_rnd100 - Simple decorator, lru size 100, argument space 100 ---
  avg (arm): 66.062 us
  avg (x86): 24.150 us
--- decorators.bg.lazy.sz100_rnd1000 - Simple decorator, lru size 100, argument space 1000 ---
  avg (arm): 1021.385 us
  avg (x86): 366.402 us
--- decorators.future.sz100_rnd100 - Simple decorator, lru size 100, argument space 100 ---
  avg (arm): 71.274 us
  avg (x86): 184.088 us
--- decorators.future.sz100_rnd1000 - Simple decorator, lru size 100, argument space 1000 ---
  avg (arm): 173.030 us
  avg (x86): 425.409 us
```

There's a lot of run to run variance, so the differences are not really statistically significant.