### PR TITLE
PY3: Benchmarks and fixes for asyncache

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,12 @@ All notable changes to this project will be documented here.
 - Renamed clients.async module to clients.asyncache
   (to make it Python 3 compatible)
 - Key/value picklers now **must** return bytes
+- Futures no longer strip exception tracebacks by default.
+  This follows Python 3's new traceback handling behavior,
+  but it may cause additional memory leaks due to the way
+  tracebacks hold references to frames and all local variables.
+  It is recommended that stripping is re-enabled for production
+  code using `chorde.clients.asyncache.set_strip_tracebacks(True)`.
 
 ## [0.9.0] - Unreleased
 ### Removed

--- a/bench/benchmarks/__init__.py
+++ b/bench/benchmarks/__init__.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import threadpool, inproc, spickle, decorators
+from . import threadpool, inproc, spickle, decorators, future
 
 BENCHMARKS = (
     threadpool.BENCHMARKS
     + inproc.BENCHMARKS
     + spickle.BENCHMARKS
     + decorators.BENCHMARKS
+    + future.BENCHMARKS
 )
 
 __all__ = ['BENCHMARKS']

--- a/bench/benchmarks/future.py
+++ b/bench/benchmarks/future.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from past.builtins import xrange as range
+
+from .base import Benchmark
+from chorde.clients.asyncache import Future
+
+
+class BenchFutureBase(Benchmark):
+
+    calibration_runs = 10000000
+    initial = 10000
+    maxruns = 10000000
+
+    bench_prefix = 'async.future.'
+    description = 'async.Future.'
+
+    def __init__(self):
+        super(BenchFutureBase, self).__init__(self.description)
+
+
+class BenchFutureGet(BenchFutureBase):
+
+    bench_prefix = 'async.future.result'
+    description = 'async.Future.result'
+
+    def setup(self):
+        f = Future()
+        f.set(3)
+        return dict(f=f)
+
+    def calibration(self, f):
+        f.result
+
+    def func(self, f):
+        f.result()
+
+
+class BenchFutureWTimeout(BenchFutureBase):
+
+    bench_prefix = 'async.future.result.wtimeout'
+    description = 'async.Future.result with timeout'
+
+    def setup(self):
+        f = Future()
+        f.set(3)
+        return dict(f=f)
+
+    def calibration(self, f):
+        f.result
+
+    def func(self, f):
+        f.result(0)
+
+
+class BenchFutureTimeout(BenchFutureBase):
+
+    bench_prefix = 'async.future.result.timeout'
+    description = 'async.Future.result timeout'
+
+    def setup(self):
+        f = Future()
+        return dict(f=f)
+
+    def calibration(self, f):
+        try:
+            f.result
+        except:
+            pass
+
+    def func(self, f):
+        try:
+            f.result(0)
+        except:
+            pass
+
+
+class BenchFutureCancelled(BenchFutureBase):
+
+    bench_prefix = 'async.future.result.cancelled'
+    description = 'async.Future.result cancelled'
+
+    def setup(self):
+        f = Future()
+        f.cancel()
+        f.set_running_or_notify_cancelled()
+        return dict(f=f)
+
+    def calibration(self, f):
+        try:
+            f.result
+        except:
+            pass
+
+    def func(self, f):
+        try:
+            f.result()
+        except:
+            pass
+
+
+class BenchFutureSet(BenchFutureBase):
+
+    bench_prefix = 'async.future.set'
+    description = 'async.Future.set'
+
+    def setup(self):
+        return {}
+
+    def calibration(self):
+        f = Future()
+        f.set
+
+    def func(self):
+        f = Future()
+        f.set(3)
+
+
+BENCHMARKS = [
+    BenchFutureGet(),
+    BenchFutureWTimeout(),
+    BenchFutureTimeout(),
+    BenchFutureCancelled(),
+    BenchFutureSet(),
+]

--- a/lib/chorde/clients/_async.pyx
+++ b/lib/chorde/clients/_async.pyx
@@ -40,8 +40,7 @@ cdef class ExceptionWrapper:
         self.value = value
 
     @cython.ccall
-    @cython.locals(strip=cython.bint)
-    def reraise(self, strip=True):
+    def reraise(self, bint strip=True):
         exc = self.value
         if strip:
             del self.value


### PR DESCRIPTION
- Change exception traceback stripping mechanism in Future
  to account for new behavior in Python 3
- Change traceback stripping to be off by default, to match
  the current behavior in Python 3
- Allow dynamically changing traceback stripping
- Fix traceback leaks by removing cached exception objects,
  sadly unworkable in Python 3 due to its behavior with
  traceback chaining (raising an exception object appends
  traceback frames to the object, so cached exceptions grow
  indefinitely)
- Fix traceback leaks through local exception variables

Will attach benchmark results later