### PR TITLE
Fix memory overallocation in coherence implementation

### DIFF
--- a/lib/chorde/mq/coherence.py
+++ b/lib/chorde/mq/coherence.py
@@ -675,7 +675,7 @@ class CoherenceManager(object):
             if txid is None:
                 txid = self.txid
             first_key = next(iter(keys))
-            self.ipsub.publish_encode(self.doneprefix+bytes(self.stable_hash(first_key)), self.encoding,
+            self.ipsub.publish_encode(self.doneprefix+str(self.stable_hash(first_key)).encode(), self.encoding,
                 (txid, keys, self.p2p_pub_binds),
                 timeout = timeout)
         return NoopWaiter()
@@ -686,7 +686,7 @@ class CoherenceManager(object):
             if txid is None:
                 txid = self.txid
             first_key = next(iter(keys))
-            self.ipsub.publish_encode(self.abortprefix+bytes(self.stable_hash(first_key)), self.encoding,
+            self.ipsub.publish_encode(self.abortprefix+str(self.stable_hash(first_key)).encode(), self.encoding,
                 (txid, keys, self.p2p_pub_binds),
                 timeout = timeout)
         return NoopWaiter()
@@ -719,7 +719,7 @@ class CoherenceManager(object):
             return True
 
         ipsub_ = self.ipsub
-        keysuffix = bytes(self.stable_hash(key))
+        keysuffix = str(self.stable_hash(key)).encode()
         doneprefix = self.doneprefix+keysuffix
         abortprefix = self.abortprefix+keysuffix
 

--- a/lib/chorde/threadpool.py
+++ b/lib/chorde/threadpool.py
@@ -285,7 +285,7 @@ class ThreadPool:
             # until now, pushing threads didn't set the weakeup call event.
             # So, before actually sleeping, try again
             self.__swap_queues()
-        elif self.__not_empty.isSet():
+        elif self.__not_empty.is_set():
             # Try again
             # Someone may have sneaked in while we were in the above case
             # and may still neak in after we clear the not_empty event
@@ -304,7 +304,7 @@ class ThreadPool:
         workset = self.__workset
         termcount = 0
         while True:
-            if (self.__dequeue is self.__exhausted and not self.__not_empty.isSet()
+            if (self.__dequeue is self.__exhausted and not self.__not_empty.is_set()
                     and (not self.queues or not any(self.queues.values()))):
                 # Sounds like there's nothing to do
                 # Yeah, gonna wait
@@ -358,10 +358,10 @@ class ThreadPool:
         # just-queued value, so avoid the actual operation
         # (which is much more expensive than checking)
         not_empty = self.__not_empty
-        if not not_empty.isSet():
+        if not not_empty.is_set():
             not_empty.set()
         empty = self.__empty
-        if empty.isSet():
+        if empty.is_set():
             empty.clear()
 
         self.assert_started()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ try:
 except:
     no_pyrex = True
 
-VERSION = "1.0.9"
+VERSION = "1.0.10"
 
 version_path = os.path.join(os.path.dirname(__file__), 'lib', 'chorde', '_version.py')
 if not os.path.exists(version_path):

--- a/tests/files.py
+++ b/tests/files.py
@@ -137,7 +137,7 @@ class FilesTest(WithTempdir, CacheClientTestMixIn, unittest.TestCase):
         maxentries = SIZE // len(bigval)
 
         for i in range(maxentries+1):
-            client.put(i, bigval+bytes(i), 86400)
+            client.put(i, bigval+str(i).encode(), 86400)
 
             time.sleep(TIME_RESOLUTION*2)
 
@@ -146,7 +146,7 @@ class FilesTest(WithTempdir, CacheClientTestMixIn, unittest.TestCase):
             self.assertTrue(client.contains(i))
             cachedval = client.get(i)
             self.assertTrue(bytearray(cachedval)[:len(bigval)] == bytearray(bigval))
-            self.assertTrue(bytearray(cachedval)[len(bigval):] == bytearray(bytes(i)))
+            self.assertTrue(bytearray(cachedval)[len(bigval):] == bytearray(str(i).encode()))
             del cachedval
         self.assertFalse(client.contains(0))
         self.assertTrue(client.contains(maxentries//2))


### PR DESCRIPTION
Due to a mistake during the migration to python 3, we were creating arbitrarily large byte arrays in some cases where the intention was to actually convert a number to string.