### PR TITLE
Add pyproject.toml for isolated build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython<3.0,>=0.22" ]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
as described in cython docs
https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html

builds using a virtualenv
Allows chorde to require its own version of cython
   - scikit-learn has moved on to requiring cython 3