### PR TITLE
Modernize CI python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                python-version: [3.7, 3.8, 3.9, "3.10"]
+                python-version: [3.9, "3.10", "3.11"]
         steps:
         - uses: actions/checkout@v2
         - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
3.7 no longer available